### PR TITLE
Work around missing tile labels on touch devices

### DIFF
--- a/src/js/html_view.js
+++ b/src/js/html_view.js
@@ -160,6 +160,10 @@ HTMLView.prototype.addTile = function (tile) {
   inner.classList.add("tile-inner");
   inner.textContent = tile.value;
 
+  inner.ontouchstart = () => inner.classList.add("hover");
+  inner.ontouchend = () => inner.classList.remove("hover");
+  inner.ontouchcancel = () => inner.classList.remove("hover");
+
   if (tile.previousPosition) {
     // Make sure that the tile gets rendered in the previous position first
     window.requestAnimationFrame(function () {

--- a/src/sass/_mod_surfer.scss
+++ b/src/sass/_mod_surfer.scss
@@ -6,7 +6,7 @@ $tiles: 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048;
     background-size: contain;
     font-size: 0;
     color: white;
-    &:hover {
+    &:hover, &.hover {
       font-size: 55px;
     }
   }


### PR DESCRIPTION
The tile labels are displayed via the :hover pseudo class. This class is
never applied for touch input (it might still work for the first touch
point which is often used for mouse emulation). This workaround adds the
new CSS class '.hover' for tiles that is added on touchstart and removed
on touchend respectively touchcancel.